### PR TITLE
UX fix. Update ADT button label if package is installed/not

### DIFF
--- a/usr/share/archlinux-tweak-tool/archlinux-tweak-tool.py
+++ b/usr/share/archlinux-tweak-tool/archlinux-tweak-tool.py
@@ -3557,7 +3557,18 @@ class Main(Gtk.Window):
         fn.enable_login_manager(self, "sddm")
 
     def on_launch_adt_clicked(self, desktop):
-        fn.install_arco_package(self, "arcolinux-desktop-trasher-git")
+        # check if package is installed and update label
+        if self.adt_installed is True:
+            fn.remove_package(self, "arcolinux-desktop-trasher-git")
+            if fn.check_package_installed("arcolinux-desktop-trasher-git") is False:
+                self.button_adt.set_label("Install the ArcoLinux Desktop Trasher")
+                self.adt_installed = False
+
+        else:
+            fn.install_package(self, "arcolinux-desktop-trasher-git")
+            if fn.check_package_installed("arcolinux-desktop-trasher-git") is True:
+                self.button_adt.set_label("Remove the ArcoLinux Desktop Trasher")
+                self.adt_installed = True
         # try:
         #    subprocess.Popen("/usr/local/bin/arcolinux-desktop-trasher")
         #    fn.show_in_app_notification(self, "ArcoLinux Desktop Trasher launched")

--- a/usr/share/archlinux-tweak-tool/desktopr_gui.py
+++ b/usr/share/archlinux-tweak-tool/desktopr_gui.py
@@ -67,10 +67,18 @@ the ArcoLinux repositories"
     self.button_install = Gtk.Button(label="Install")
     self.button_reinstall = Gtk.Button(label="Re-Install")
 
-    button_adt = Gtk.Button(label="Install the ArcoLinux Desktop Trasher")
-    button_adt.set_margin_top(70)
-    button_adt.set_size_request(100, 20)
-    button_adt.connect("clicked", self.on_launch_adt_clicked)
+    self.button_adt = Gtk.Button()
+    self.button_adt.set_margin_top(70)
+    self.button_adt.set_size_request(100, 20)
+
+    if fn.check_package_installed("arcolinux-desktop-trasher-git") is True:
+        self.adt_installed = True
+        self.button_adt.set_label("Remove the ArcoLinux Desktop Trasher")
+        self.button_adt.connect("clicked", self.on_launch_adt_clicked)
+    else:
+        self.adt_installed = False
+        self.button_adt.set_label("Install the ArcoLinux Desktop Trasher")
+        self.button_adt.connect("clicked", self.on_launch_adt_clicked)
 
     self.button_install.connect("clicked", self.on_install_clicked, "inst")
     self.button_reinstall.connect("clicked", self.on_install_clicked, "reinst")
@@ -157,7 +165,7 @@ Hyprland and Wayfire are Wayland desktops!"
     vbox1 = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
     vbox1.pack_start(hbox, False, False, 10)
     if fn.distr == "arcolinux":
-        vbox1.pack_start(button_adt, False, True, 10)
+        vbox1.pack_start(self.button_adt, False, True, 10)
     vbox1.pack_end(vboxprog, False, False, 0)
     # =======================================
     #               PACK TO WINDOW


### PR DESCRIPTION
If ADT is already installed label now shows "Remove the ArcoLinux Desktop Trasher" else it shows "Install the ArcoLinux Desktop Trasher"

![Screenshot_20240511_094125](https://github.com/arcolinux/archlinux-tweak-tool-dev/assets/121581829/dd10281c-12cf-4138-b43c-4f33e9f17cc1)
![Screenshot_20240511_094206](https://github.com/arcolinux/archlinux-tweak-tool-dev/assets/121581829/02cf5cf5-76d1-449f-9bc8-121be53455dd)
