### PR TITLE
Loclcat now sync with fastfetch disabled and Ascii and logos are out

### DIFF
--- a/usr/share/archlinux-tweak-tool/archlinux-tweak-tool.py
+++ b/usr/share/archlinux-tweak-tool/archlinux-tweak-tool.py
@@ -134,7 +134,7 @@ class Main(Gtk.Window):
 
         while Gtk.events_pending():
             Gtk.main_iteration()
-
+        
         # t = fn.threading.Thread(target=fn.get_desktop,
         #                                args=(self,))
         # t.daemon = True
@@ -879,7 +879,7 @@ class Main(Gtk.Window):
 
             self.fastfetch_util.set_active(utilities.get_term_rc("fastfetch"))
             self.fast_util.set_active(utilities.get_term_rc("fastfetch"))
-
+    
         # =====================================================
         #                     LIGHTDM
         # =====================================================
@@ -2796,32 +2796,31 @@ class Main(Gtk.Window):
     def on_apply_fast(self, widget):
         small_ascii = "auto"
         backend = "off"
+    #    if self.asci.get_active():
+    #        backend = "ascii"
+    #        if not self.big_ascii.get_active() and not self.off.get_active():
+    #            small_ascii = "arch_small"
+    #            if fn.distr == "arcolinux":
+    #                small_ascii = "arcolinux_small"
+    #            if fn.distr == "archlinux":
+    #               small_ascii = "arch_small"
+    #           if fn.distr == "manjaro":
+    #               small_ascii = "manjaro_small"
+    #            backend = "ascii"
+    #        elif not self.small_ascii.get_active() and not self.off.get_active():
+    #            backend = "ascii"
+    #        else:
+    #            backend = "off"
 
-        if self.asci.get_active():
-            backend = "ascii"
-            if not self.big_ascii.get_active() and not self.off.get_active():
-                small_ascii = "arch_small"
-                if fn.distr == "arcolinux":
-                    small_ascii = "arcolinux_small"
-                if fn.distr == "archlinux":
-                    small_ascii = "arch_small"
-                if fn.distr == "manjaro":
-                    small_ascii = "manjaro_small"
-                backend = "ascii"
-            elif not self.small_ascii.get_active() and not self.off.get_active():
-                backend = "ascii"
-            else:
-                backend = "off"
-
-        if self.distro_ascii.get_active_text() != "auto" and not self.off.get_active():
-            small_ascii = self.distro_ascii.get_active_text()
-            if self.small_ascii.get_active():
-                if self.distro_ascii.get_active_text() == "ArcoLinux":
-                    small_ascii = "arcolinux_small"
-                if self.distro_ascii.get_active_text() == "Arch":
-                    small_ascii = "arch_small"
-                if self.distro_ascii.get_active_text() == "Manjaro":
-                    small_ascii = "manjaro_small"
+    #    if self.distro_ascii.get_active_text() != "auto" and not self.off.get_active():
+    #        small_ascii = self.distro_ascii.get_active_text()
+    #        if self.small_ascii.get_active():
+    #            if self.distro_ascii.get_active_text() == "ArcoLinux":
+    #                small_ascii = "arcolinux_small"
+    #            if self.distro_ascii.get_active_text() == "Arch":
+    #                small_ascii = "arch_small"
+    #            if self.distro_ascii.get_active_text() == "Manjaro":
+    #               small_ascii = "manjaro_small"
 
         fastfetch.apply_config(self, backend, small_ascii)
 
@@ -2837,21 +2836,21 @@ class Main(Gtk.Window):
         if fn.path.isfile(fn.fastfetch_config + ".bak"):
             fn.shutil.copy(fn.fastfetch_config + ".bak", fn.fastfetch_config)
 
-            backend = fastfetch.check_backend()
-            if backend == "ascii":
-                self.asci.set_active(True)
+    #        backend = fastfetch.check_backend()
+    #        if backend == "ascii":
+    #            self.asci.set_active(True)
 
             fastfetch.get_checkboxes(self)
             print("fastfetch default settings applied")
             fn.show_in_app_notification(self, "Default settings applied")
 
-    def radio_toggled(self, widget):
-        if self.asci.get_active():
-            self.big_ascii.set_sensitive(True)
-            self.small_ascii.set_sensitive(True)
-        else:
-            self.big_ascii.set_sensitive(False)
-            self.small_ascii.set_sensitive(False)
+    #def radio_toggled(self, widget):
+    #    if self.asci.get_active():
+    #        self.big_ascii.set_sensitive(True)
+    #        self.small_ascii.set_sensitive(True)
+    #    else:
+    #        self.big_ascii.set_sensitive(False)
+    #        self.small_ascii.set_sensitive(False)
     
     # When using this function to toggle a lolcat: utility = name of tool, e.g. fastfetch
     def lolcat_toggle(self, widget, active, utility):
@@ -2870,6 +2869,13 @@ class Main(Gtk.Window):
         elif widget.get_active() is False and utility == "fastfetch":
             utilities.set_util_state(self, utility, True, False)
         utilities.write_configs(utility, util_str)
+    
+    def on_fast_util_toggled(self, switch, gparam):
+        if not switch.get_active():
+            self.fast_lolcat.set_active(False) 
+
+            self.fast_util.connect("notify::active", self.on_fast_util_toggled)
+
 
     def util_toggle(self, widget, active, utility):
         util_str = utility

--- a/usr/share/archlinux-tweak-tool/fastfetch_gui.py
+++ b/usr/share/archlinux-tweak-tool/fastfetch_gui.py
@@ -26,25 +26,25 @@ def gui(self, Gtk, vboxstack8, fastfetch, fn):
     )
     hbox23.pack_start(warning_label, False, False, 10)
 
-    self.asci = Gtk.RadioButton(label="Enable ascii backend")
-    self.asci.connect("toggled", self.radio_toggled)
+    #self.asci = Gtk.RadioButton(label="Enable ascii backend")
+    #self.asci.connect("toggled", self.radio_toggled)
 
-    self.off = Gtk.RadioButton.new_from_widget(self.asci)
-    self.off.set_label("No backend")
-    self.off.connect("toggled", self.radio_toggled)
+    #self.off = Gtk.RadioButton.new_from_widget(self.asci)
+    #self.off.set_label("No backend")
+    #self.off.connect("toggled", self.radio_toggled)
 
-    self.distro_ascii = Gtk.ComboBoxText()
-    fastfetch.pop_distro_combobox(self, self.distro_ascii)
+    #self.distro_ascii = Gtk.ComboBoxText()
+    #fastfetch.pop_distro_combobox(self, self.distro_ascii)
     # self.distro_ascii.connect("changed", self.on_distro_ascii_changed)
-    self.distro_ascii.set_active(0)
+    #self.distro_ascii.set_active(0)
 
-    self.big_ascii = Gtk.RadioButton(label="Use normal ascii")
+    #self.big_ascii = Gtk.RadioButton(label="Use normal ascii")
 
-    self.small_ascii = Gtk.RadioButton.new_from_widget(self.big_ascii)
-    self.small_ascii.set_label("Use small ascii")
+    #self.small_ascii = Gtk.RadioButton.new_from_widget(self.big_ascii)
+    #self.small_ascii.set_label("Use small ascii")
 
-    backend = fastfetch.check_backend()
-    asci = fastfetch.check_ascii()
+    #backend = fastfetch.check_backend()
+    #asci = fastfetch.check_ascii()
 
     applyfastfetch = Gtk.Button(label="Apply Fastfetch configuration")
     resetnormalfastfetch = Gtk.Button(label="Reset Fastfetch")
@@ -99,7 +99,8 @@ def gui(self, Gtk, vboxstack8, fastfetch, fn):
     lolcat_label = Gtk.Label(xalign=0)
     lolcat_label.set_markup("Use lolcat")
     self.fast_util = Gtk.Switch()
-    self.fast_util.connect("notify::active", self.util_toggle, "fastfetch")
+    #self.fast_util.connect("notify::active", self.util_toggle, "fastfetch")
+    self.fast_util.connect("notify::active", self.on_fast_util_toggled)
     fast_util_label = Gtk.Label(xalign=0)
     fast_util_label.set_markup("Fastfetch enabled")
 
@@ -179,12 +180,12 @@ Switch to the default fastfetch to use this tab - delete the ~/.config/fastfetch
     hbox29.pack_start(label29, False, False, 10)
 
     # hbox22.pack_start(self.w3m, True, False, 10)
-    hbox22.pack_end(self.off, True, False, 10)
-    hbox22.pack_end(self.asci, True, False, 10)
+    #hbox22.pack_end(self.off, True, False, 10)
+    #hbox22.pack_end(self.asci, True, False, 10)
 
-    self.hbox26.pack_start(self.distro_ascii, True, False, 10)
-    self.hbox26.pack_start(self.big_ascii, True, False, 10)
-    self.hbox26.pack_start(self.small_ascii, True, False, 10)
+    #self.hbox26.pack_start(self.distro_ascii, True, False, 10)
+    #self.hbox26.pack_start(self.big_ascii, True, False, 10)
+    #self.hbox26.pack_start(self.small_ascii, True, False, 10)
 
     hbox25.pack_start(flowbox, True, True, 10)
 
@@ -217,18 +218,23 @@ Switch to the default fastfetch to use this tab - delete the ~/.config/fastfetch
 
     vboxstack8.pack_end(hbox24, False, False, 0)
 
-    if backend == "ascii":
-        self.asci.set_active(True)
-        self.big_ascii.set_sensitive(True)
-        self.small_ascii.set_sensitive(True)
-    elif backend == "off":
-        self.off.set_active(True)
-        self.big_ascii.set_sensitive(False)
-        self.small_ascii.set_sensitive(False)
-    else:
-        # self.w3m.set_active(True)
-        self.big_ascii.set_sensitive(False)
-        self.small_ascii.set_sensitive(False)
+    #if backend == "ascii":
+    #    self.asci.set_active(True)
+    #    self.big_ascii.set_sensitive(True)
+    #    self.small_ascii.set_sensitive(True)
+    #elif backend == "off":
+    #    self.off.set_active(True)
+    #    self.big_ascii.set_sensitive(False)
+    #    self.small_ascii.set_sensitive(False)
+    #else:
+    #    # self.w3m.set_active(True)
+    #    self.big_ascii.set_sensitive(False)
+    #    self.small_ascii.set_sensitive(False)
 
-    if asci == "auto":
-        self.big_ascii.set_active(True)
+    #if asci == "auto":
+    #    self.big_ascii.set_active(True)
+
+def on_fast_util_toggled(self, switch, gparam):
+    if not switch.get_active():
+        self.fast_lolcat.set_active(False)
+


### PR DESCRIPTION
So the built-in json module for python does not support json with comments by default. To add that support we would need to pip install jsoncomments -  so Ascii and logos are out - code has been commented out.

fastfetch and lolcat are now toggled off together