### PR TITLE
handle seperator and no lolcat without fastfetch enabled

### DIFF
--- a/usr/share/archlinux-tweak-tool/fastfetch.py
+++ b/usr/share/archlinux-tweak-tool/fastfetch.py
@@ -32,26 +32,47 @@ def toggle_fastfetch(enable):
         with open(shell_config, "r", encoding="utf-8") as f:
             lines = f.readlines()
         
-        reporting_section = next((i for i, line in enumerate(lines) if "# reporting tools" in line.lower()), None)
-        if reporting_section is None:
-            return False
-
-        fastfetch_lines = [i for i in range(reporting_section, len(lines)) 
-                           if any(keyword in lines[i].lower() for keyword in ["fastfetch", "alias ff=", "alias nfastfetch="])]
+        fastfetch_lines = [i for i, line in enumerate(lines) 
+                           if any(keyword in line.lower() for keyword in ["fastfetch", "alias ff="])]
         
-        if not fastfetch_lines:
-            return False
         for line in fastfetch_lines:
             if enable:
                 lines[line] = lines[line].lstrip('#')
             else:
                 if not lines[line].strip().startswith('#'):
                     lines[line] = '#' + lines[line]
+        
         with open(shell_config, "w", encoding="utf-8") as f:
             f.writelines(lines)
         return True
     except Exception:
         return False
+
+def toggle_lolcat(enable):
+    """Toggle lolcat for fastfetch in shell config file"""
+    shell_config = fn.get_shell_config()
+    if not shell_config:
+        return False
+
+    try:
+        with open(shell_config, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        
+        lolcat_lines = [i for i, line in enumerate(lines) 
+                        if "| lolcat" in line.lower()]
+        
+        for line in lolcat_lines:
+            if enable:
+                lines[line] = lines[line].replace("# alias ff='fastfetch", "alias ff='fastfetch")
+            else:
+                lines[line] = lines[line].replace("alias ff='fastfetch", "# alias ff='fastfetch")
+        
+        with open(shell_config, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        return True
+    except Exception:
+        return False
+
 def check_backend():
     """See if image backend is active."""
     if fn.path.isfile(fn.fastfetch_config):
@@ -62,15 +83,6 @@ def check_backend():
                 return image_backend.strip('"')
     return "ascii"
 
-def check_ascii():
-    """See if ASCII distro is active."""
-    if fn.path.isfile(fn.fastfetch_config):
-        config = get_fastfetch()
-        if config:
-            ascii_distro = config.get("ascii_distro", "auto")
-            return ascii_distro.strip('"')
-    return "auto"
-
 def apply_config(self, backend, ascii_size):
     """Apply fastfetch configuration"""
     if fn.path.isfile(fn.fastfetch_config):
@@ -78,7 +90,6 @@ def apply_config(self, backend, ascii_size):
             lines = f.readlines()
 
         # Mapping keys to checkboxes
-        # Reads config file line by line for each model
         key_to_checkbox = {
             '"os"': self.os,
             '"host"': self.host,
@@ -106,7 +117,7 @@ def apply_config(self, backend, ascii_size):
             '"poweradapter"': self.pwr,
             '"locale"': self.local,
             '"title"': self.title,
-            '"underline"': self.title,  # Assuming underline is tied to the title checkbox
+            '"underline"': self.title,
             '"colors"': self.cblocks,
         }
  
@@ -124,47 +135,6 @@ def apply_config(self, backend, ascii_size):
             f.writelines(lines)
 
         fn.show_in_app_notification(self, "fastfetch settings saved successfully")
-
-def get_checkbox_state(self, key):
-    """Return the state of the checkbox corresponding to the given key."""
-    # Mapping keys to checkboxes
-    key_to_checkbox = {
-        '"OS"': self.os,
-        '"Host"': self.host,
-        '"Kernel"': self.kernel,
-        '"Uptime"': self.uptime,
-        '"Packages"': self.packages,
-        '"Shell"': self.shell,
-        '"Display"': self.display,
-        '"DE"': self.de,
-        '"WM"': self.wm,
-        '"WM Theme"': self.wmtheme,
-        '"Theme"': self.themes,
-        '"Icons"': self.icons,
-        '"Font"': self.font,
-        '"Cursor"': self.cursor,
-        '"Terminal"': self.term,
-        '"Terminal Font"': self.termfont,
-        '"CPU"': self.cpu,
-        '"GPU"': self.gpu,
-        '"Memory"': self.mem,
-        '"Swap"': self.swap,
-        '"PowerAdapter"': self,
-        '"Disk"': self.disks,
-        '"Local IP"': self.lIP,
-        '"Battery"': self.batt,
-        '"Power Adapter"': self.pwr,
-        '"Locale"': self.local,
-        '"title"': self.title,
-        '"underline"': self.title,  
-        '"Color Blocks"': self.cblocks,
-    }
-
-    checkbox = key_to_checkbox.get(key)
-    if checkbox is not None:
-        return checkbox.get_active()
-
-    return None
 
 def get_checkboxes(self):
     """Read the state of the checkboxes from the JSONC configuration."""
@@ -199,11 +169,8 @@ def get_checkboxes(self):
     self.local.set_active(config.get("info", {}).get("Locale", False))
     self.cblocks.set_active(config.get("info", {}).get("Color Blocks", False))
 
-    # Setting the color blocks checkbox based on the configuration
-    #self.cblocks.set_active(config.get("color_blocks", "off") == "on")
-
 def set_checkboxes_normal(self):
-    """Set the state of the checkboxes to the default or normal state."""
+    """set the state of the checkboxes and ensure separator is uncommented"""
     self.title.set_active(True)
     self.os.set_active(True)
     self.host.set_active(True)
@@ -231,9 +198,11 @@ def set_checkboxes_normal(self):
     self.pwr.set_active(True)
     self.local.set_active(False)
     self.cblocks.set_active(False)
+    
+    _ensure_separator_uncommented()
 
 def set_checkboxes_small(self):
-    """set the state of the checkboxes"""
+    """set the state of the checkboxes and ensure separator is uncommented"""
     self.title.set_active(True)
     self.os.set_active(False)
     self.host.set_active(False)
@@ -261,9 +230,11 @@ def set_checkboxes_small(self):
     self.pwr.set_active(True)
     self.local.set_active(False)
     self.cblocks.set_active(False)
+    
+    _ensure_separator_uncommented()
 
 def set_checkboxes_all(self):
-    """set the state of the checkboxes"""
+    """set the state of the checkboxes and ensure separator is uncommented"""
     self.title.set_active(True)
     self.os.set_active(True)
     self.host.set_active(True)
@@ -292,8 +263,10 @@ def set_checkboxes_all(self):
     self.local.set_active(True)
     self.cblocks.set_active(True)
     
+    _ensure_separator_uncommented()
+    
 def set_checkboxes_none(self):
-    """set the state of the checkboxes"""
+    """set the state of the checkboxes and comment out separator in config.jsonc"""
     self.title.set_active(False)
     self.os.set_active(False)
     self.host.set_active(False)
@@ -321,113 +294,31 @@ def set_checkboxes_none(self):
     self.pwr.set_active(False)
     self.local.set_active(False)
     self.cblocks.set_active(False)
-
-#def pop_distro_combobox(self, combo):
-#    """Populate the distro combo box with available options."""
     
-    # Clear the existing items in the combo box
-#    combo.get_model().clear()
-    
-    # List of available distributions and operating systems
-#    list_distros = [
-#        "auto",
-#         "Antergos",
-#        "Anarchy",
-#        "Android",
-#        "Antergos",
-#        "antiX",
-#        "ArcoLinux",
-#        "ArchBox",
-#        "ARCHlabs",
-#        "ArchStrike",
-#        "Arch",
-#        "Artix",
-#        "Arya",
-#        "Bedrock",
-#        "BlackArch",
-#        "BSD",
-#        "BunsenLabs",
-#        "CentOS",
-#        "Chakra",
-#        "ClearOS",
-#        "Debian",
-#        "Deepin",
-#        "Elementary",
-#        "EndeavourOS",
-#        "Fedora",
-#        "Feren",
-#        "FreeBSD",
-#        "Frugalware",
-#        "Funtoo",
-#        "Garuda",
-#       "Gentoo",
-#        "GNOME",
-#        "GNU",
-#        "Kali",
-#        "KaOS",
-#        "KDE_neon",
-#        "Kubuntu",
-#        "LMDE",
-#        "Lubuntu",
-#        "macos",
-#        "Mageia",
-#        "MagpieOS",
-#        "Mandriva",
-#        "Manjaro",
-#        "Maui",
-#        "LinuxMint",
-#        "MX_Linux",
-#        "Namib",
-#        "NetBSD",
-#        "Netrunner",
-#        "Nitrux",
-#        "NixOS",
-#        "OBRevenge",
-#        "OpenBSD",
-#        "OpenMandriva",
-#        "Oracle",
-#        "PCLinuxOS",
-#        "Peppermint",
-#        "popos",
-#        "Puppy",
-#        "PureOS",
-#        "Raspbian",
-#        "Reborn_OS",
-#        "Redcore",
-#        "Redhat",
-#        "SalentOS",
-#       "Slackware",
-#        "Solus",
-#        "SteamOS",
-#        "SunOS",
-#        "openSUSE_Leap",
-#        "openSUSE_Tumbleweed",
-#        "openSUSE",
-#       "SwagArch",
-#        "Ubuntu-Budgie",
-#        "Ubuntu-GNOME",
-#        "Ubuntu-MATE",
-#        "Ubuntu-Studio",
-#        "Ubuntu",
-#        "Venom",
-#        "Void",
-#        "windows10",
-#        "Windows7",
-#        "Xubuntu",
-#        "Zorin",
-#    ]
+    _ensure_separator_commented()
 
-    # Add each distro to the combo box
-    #for item in list_distros:
-    #    combo.append_text(item)
+def _ensure_separator_uncommented():
+    """Ensure the separator in config.jsonc is uncommented"""
+    if fn.path.isfile(fn.fastfetch_config):
+        with open(fn.fastfetch_config, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        
+        for i, line in enumerate(lines):
+            if '"separator"' in line and line.strip().startswith('//'):
+                lines[i] = line.lstrip('/')
 
-    # Optional: Automatically set the active item based on a config value
-    # Uncomment and adjust the following code if you want to pre-select an item
-    # try:
-    #     name = fn.get_position(fn.fastfetch_config, "ascii_distro=").split("=")[1].strip().lower()
-    #     for i, item in enumerate(list_distros):
-    #         if name == item.lower():
-    #             combo.set_active(i)
-    #             break
-    # except IndexError:
-    #     pass
+        with open(fn.fastfetch_config, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+def _ensure_separator_commented():
+    """Ensure the separator in config.jsonc is commented out"""
+    if fn.path.isfile(fn.fastfetch_config):
+        with open(fn.fastfetch_config, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        
+        for i, line in enumerate(lines):
+            if '"separator"' in line and not line.strip().startswith('//'):
+                lines[i] = '//' + line
+
+        with open(fn.fastfetch_config, "w", encoding="utf-8") as f:
+            f.writelines(lines)

--- a/usr/share/archlinux-tweak-tool/fastfetch_gui.py
+++ b/usr/share/archlinux-tweak-tool/fastfetch_gui.py
@@ -3,6 +3,7 @@
 # ============================================================
 # pylint:disable=C0103,
 import fastfetch
+import utilities
 
 def gui(self, Gtk, vboxstack8, fastfetch, fn):
     """create a gui"""
@@ -36,35 +37,12 @@ def gui(self, Gtk, vboxstack8, fastfetch, fn):
     fast_lolcat_label = Gtk.Label(xalign=0)
     fast_lolcat_label.set_markup("Lolcat enabled")
 
-
-    #self.asci = Gtk.RadioButton(label="Enable ascii backend")
-    #self.asci.connect("toggled", self.radio_toggled)
-
-    #self.off = Gtk.RadioButton.new_from_widget(self.asci)
-    #self.off.set_label("No backend")
-    #self.off.connect("toggled", self.radio_toggled)
-
-    #self.distro_ascii = Gtk.ComboBoxText()
-    #fastfetch.pop_distro_combobox(self, self.distro_ascii)
-    # self.distro_ascii.connect("changed", self.on_distro_ascii_changed)
-    #self.distro_ascii.set_active(0)
-
-    #self.big_ascii = Gtk.RadioButton(label="Use normal ascii")
-
-    #self.small_ascii = Gtk.RadioButton.new_from_widget(self.big_ascii)
-    #self.small_ascii.set_label("Use small ascii")
-
-    #backend = fastfetch.check_backend()
-    #asci = fastfetch.check_ascii()
-
     applyfastfetch = Gtk.Button(label="Apply Fastfetch configuration")
     resetnormalfastfetch = Gtk.Button(label="Reset Fastfetch")
-    #useattfastfetch = Gtk.Button(label="Use Default config")
     installfastfetch = Gtk.Button(label="Install Fastfetch")
 
     applyfastfetch.connect("clicked", self.on_apply_fast)
     resetnormalfastfetch.connect("clicked", self.on_reset_fast)
-    #useattfastfetch.connect("clicked", self.on_reset_fast_att)
     installfastfetch.connect("clicked", self.on_install_fast)
 
     hbox22 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
@@ -104,49 +82,6 @@ def gui(self, Gtk, vboxstack8, fastfetch, fn):
     self.pwr = Gtk.CheckButton(label="Show power adapter")
     self.title = Gtk.CheckButton(label="Show title")
     self.cblocks = Gtk.CheckButton(label="Show color blocks")
-
-    self.fast_lolcat = Gtk.Switch()
-    self.fast_lolcat.connect("notify::active", self.lolcat_toggle, "fastfetch")
-    lolcat_label = Gtk.Label(xalign=0)
-    lolcat_label.set_markup("Use lolcat")
-    self.fast_util = Gtk.Switch()
-    #self.fast_util.connect("notify::active", self.util_toggle, "fastfetch")
-    self.fast_util.connect("notify::active", self.on_fast_util_toggled)
-    fast_util_label = Gtk.Label(xalign=0)
-    fast_util_label.set_markup("Fastfetch enabled")
-
-    flowbox = Gtk.FlowBox()
-    flowbox.set_valign(Gtk.Align.START)
-    flowbox.set_max_children_per_line(10)
-    flowbox.set_selection_mode(Gtk.SelectionMode.NONE)
-
-    flowbox.add(self.title)
-    flowbox.add(self.os)
-    flowbox.add(self.host)
-    flowbox.add(self.kernel)
-    flowbox.add(self.uptime)
-    flowbox.add(self.packages)
-    flowbox.add(self.shell)
-    flowbox.add(self.display)
-    flowbox.add(self.de)
-    flowbox.add(self.wm)
-    flowbox.add(self.wmtheme)
-    flowbox.add(self.themes)
-    flowbox.add(self.icons)
-    flowbox.add(self.font)
-    flowbox.add(self.cursor)
-    flowbox.add(self.term)
-    flowbox.add(self.termfont)
-    flowbox.add(self.cpu)
-    flowbox.add(self.gpu)
-    flowbox.add(self.mem)
-    flowbox.add(self.swap)
-    flowbox.add(self.disks)
-    flowbox.add(self.lIP)
-    flowbox.add(self.batt)
-    flowbox.add(self.pwr)
-    flowbox.add(self.local)
-    flowbox.add(self.cblocks)
 
     fastfetch.get_checkboxes(self)
 
@@ -190,23 +125,47 @@ Switch to the default fastfetch to use this tab - delete the ~/.config/fastfetch
     )
     hbox29.pack_start(label29, False, False, 10)
 
-    # hbox22.pack_start(self.w3m, True, False, 10)
-    #hbox22.pack_end(self.off, True, False, 10)
-    #hbox22.pack_end(self.asci, True, False, 10)
+    flowbox = Gtk.FlowBox()
+    flowbox.set_valign(Gtk.Align.START)
+    flowbox.set_max_children_per_line(10)
+    flowbox.set_selection_mode(Gtk.SelectionMode.NONE)
 
-    #self.hbox26.pack_start(self.distro_ascii, True, False, 10)
-    #self.hbox26.pack_start(self.big_ascii, True, False, 10)
-    #self.hbox26.pack_start(self.small_ascii, True, False, 10)
+    flowbox.add(self.title)
+    flowbox.add(self.os)
+    flowbox.add(self.host)
+    flowbox.add(self.kernel)
+    flowbox.add(self.uptime)
+    flowbox.add(self.packages)
+    flowbox.add(self.shell)
+    flowbox.add(self.display)
+    flowbox.add(self.de)
+    flowbox.add(self.wm)
+    flowbox.add(self.wmtheme)
+    flowbox.add(self.themes)
+    flowbox.add(self.icons)
+    flowbox.add(self.font)
+    flowbox.add(self.cursor)
+    flowbox.add(self.term)
+    flowbox.add(self.termfont)
+    flowbox.add(self.cpu)
+    flowbox.add(self.gpu)
+    flowbox.add(self.mem)
+    flowbox.add(self.swap)
+    flowbox.add(self.disks)
+    flowbox.add(self.lIP)
+    flowbox.add(self.batt)
+    flowbox.add(self.pwr)
+    flowbox.add(self.local)
+    flowbox.add(self.cblocks)
 
     hbox25.pack_start(flowbox, True, True, 10)
 
     hbox27.pack_start(fast_util_label, False, False, 10)
     hbox27.pack_start(self.fast_util, False, False, 30)
-    hbox27.pack_start(lolcat_label, False, False, 0)
+    hbox27.pack_start(fast_lolcat_label, False, False, 0)
     hbox27.pack_start(self.fast_lolcat, False, False, 30)
 
     hbox24.pack_start(installfastfetch, False, False, 0)
-    #hbox24.pack_start(useattfastfetch, False, False, 0)
     hbox24.pack_end(applyfastfetch, False, False, 0)
     hbox24.pack_end(resetnormalfastfetch, False, False, 0)
 
@@ -229,26 +188,36 @@ Switch to the default fastfetch to use this tab - delete the ~/.config/fastfetch
 
     vboxstack8.pack_end(hbox24, False, False, 0)
 
-    #if backend == "ascii":
-    #    self.asci.set_active(True)
-    #    self.big_ascii.set_sensitive(True)
-    #    self.small_ascii.set_sensitive(True)
-    #elif backend == "off":
-    #    self.off.set_active(True)
-    #    self.big_ascii.set_sensitive(False)
-    #    self.small_ascii.set_sensitive(False)
-    #else:
-    #    # self.w3m.set_active(True)
-    #    self.big_ascii.set_sensitive(False)
-    #    self.small_ascii.set_sensitive(False)
-
-    #if asci == "auto":
-    #    self.big_ascii.set_active(True)
+    # Initialize lolcat switch sensitivity based on fastfetch state
+    self.fast_lolcat.set_sensitive(self.fast_util.get_active())
 
 def on_fast_util_toggled(self, switch, gparam):
-    fastfetch.toggle_fastfetch(switch.get_active())
-    if not switch.get_active():
+    util_state = switch.get_active()
+    lolcat_state = self.fast_lolcat.get_active()
+    
+    try:
+        fastfetch.toggle_fastfetch(util_state)
+    except Exception as e:
+        print(f"Error calling fastfetch.toggle_fastfetch: {str(e)}")
+    
+    if not util_state:
         self.fast_lolcat.set_active(False)
+        lolcat_state = False
+        fastfetch.toggle_lolcat(False)
+    
+    utilities.write_configs("fastfetch", util_state, lolcat_state)
+    self.fast_lolcat.set_sensitive(util_state)
 
 def on_fast_lolcat_toggled(self, switch, gparam):
-    fastfetch.toggle_lolcat(switch.get_active())
+    lolcat_state = switch.get_active()
+    util_state = self.fast_util.get_active()
+    
+    if util_state:
+        fastfetch.toggle_lolcat(lolcat_state)
+        utilities.write_configs("fastfetch", util_state, lolcat_state)
+    else:
+        switch.set_active(False)  # Ensure lolcat stays off if fastfetch is off
+
+def update_gui(self):
+    # Your code to update the GUI goes here
+    pass


### PR DESCRIPTION
If choose None - it will now comment out the seperator bar and if choose all small or normal it will add back into the config - the other option would be too add to the checkbox as an option to enable or disable by itself. 

As for the lolcat being enabled before fastfetch - I could not get it to handle that option like you wanted so i implemented a workaround - lolcat can not be toggled on with fastfetch first being enabled.